### PR TITLE
Update International Posters title, link, and description

### DIFF
--- a/content/brilliant.mdx
+++ b/content/brilliant.mdx
@@ -8,3 +8,5 @@
 Brilliant is a online platform for learning STEM topics using interactive learning. Brilliant Premium unlocks all courses on Brilliant.
 
 Brilliant is offering all Hack Clubbers free Brilliant Premium. Fill out this form <Code>recYV0odLlxdaBpgV</Code> to get Brilliant Premium!
+
+Note: It may look like you don't have premium, but you'll still be able to access all the courses.

--- a/manifest.js
+++ b/manifest.js
@@ -45,11 +45,11 @@ export default [
         forUseBy: "leaders",
       },
       {
-        name: "Posters - Europe",
-        description: "If you're in Europe, get large Hack Club posters to promote your Hack Club",
+        name: "International Posters",
+        description: "If you're outside of US/Canada, get large Hack Club posters to promote your Hack Club",
         icon: "docs-fill",
         external: true,
-        url: "https://hack.club/eu-posters",
+        url: "https://hack.club/intl-posters",
         forUseBy: "leaders",
       },
       {


### PR DESCRIPTION
Update the title, link, and description for the "Posters - Europe" section in `manifest.js`.

* Change the title from "Posters - Europe" to "International Posters"
* Update the link from "https://hack.club/eu-posters" to "https://hack.club/intl-posters"
* Update the description to include the message "If you're outside of US/Canada, get large Hack Club posters to promote your Hack Club"

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/leowilkin/toolbox?shareId=1390a346-088b-4d26-8f50-b284d95c56b8).