### PR TITLE
Add note about Brilliant Premium access

### DIFF
--- a/content/brilliant.mdx
+++ b/content/brilliant.mdx
@@ -8,3 +8,5 @@
 Brilliant is a online platform for learning STEM topics using interactive learning. Brilliant Premium unlocks all courses on Brilliant.
 
 Brilliant is offering all Hack Clubbers free Brilliant Premium. Fill out this form <Code>recYV0odLlxdaBpgV</Code> to get Brilliant Premium!
+
+Note: It may look like you don't have premium, but you'll still be able to access all the courses.


### PR DESCRIPTION
Add a note to the Brilliant Premium perk page indicating that it may look like you don't have premium, but you'll still be able to access all the courses.

* Modify `content/brilliant.mdx` to include the new note at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/leowilkin/toolbox?shareId=4b8fd240-dffb-4bc6-ac3b-e55eb665b696).